### PR TITLE
ISSUE50:fix:CSI logo is always visible

### DIFF
--- a/Find-CSI/script.js
+++ b/Find-CSI/script.js
@@ -81,7 +81,7 @@ function randomcsi(){
 	var winHeight2 = window.innerHeight;
 
 	randomTop2 = getRandomNumber(0, winHeight2);
-	randomLeft2 = getRandomNumber(0, winWidth2);
+	randomLeft2 = getRandomNumber(0, winWidth2)+600;
 
 	document.getElementById('csi').style.top= randomTop2 +"px";
 	document.getElementById('csi').style.left = randomLeft2 +"px";


### PR DESCRIPTION
@SubstantialCattle5 
I've fixed this bug, now the CSI logo never hides behind the Shinchan image. Please have a look.